### PR TITLE
fix image-rb spel

### DIFF
--- a/db/migrate/20200412080057_create_images.rb
+++ b/db/migrate/20200412080057_create_images.rb
@@ -1,7 +1,7 @@
 class CreateImages < ActiveRecord::Migration[5.2]
   def change
     create_table :images do |t|
-      t.bight "item_id", null: false
+      t.bigint "item_id", null: false
       t.string :image, null: false
       t.timestamps
     end


### PR DESCRIPTION
#what
imageテーブルのt.bigint "item_id", null: false部分にスペルミスがあったので、修正しました。

#why
他のメンバーの方が開発用ブランチにマスターブランチをの最新コードを取り込む際にエラーが出ないようにするため。