### PR TITLE
出品ボタン追加

### DIFF
--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -1,5 +1,19 @@
 $colorwhite: white;
 
+.sellbtn {
+  position: fixed;
+  top: 79%;
+  left: 90%;
+  height: 120px;
+  width: 120px;
+  z-index: 1;
+  background-color: #3CCACE;
+  text-align: center;
+  line-height: 2.3;
+  border-radius: 4%;
+  color: white;
+}
+
 .main__page {
   padding: 220px 60px;
 }

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,126 +1,132 @@
-= render partial: 'items/main-header'
-.main1
-  .main1__page
-    .main1__title
-      %h1 人生を変えるフリマアプリ
-    .main1__subtitle
-      %p FURIMAはだれでもかんたんに出品・購入できる
-      %p フリマアプリです
-    .main1__btn
-      .main1__btn--apple
-        = image_tag('/assets/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg',size: '180x53')
-      .main1__btn--google
-        = image_tag('/assets/google-play-badge.png',size: '200x73')
-.main2
-  .main2__page
-    .main2__heading
-      %h2 FURIMAが選ばれる3つの理由
-    %ul.main2__title
-      %li.main2__title__left
-        = image_tag('/assets/pict-reason-01.jpg',size: '280x280')
-        %span 
-          .main2__title__left--num
-            1
-        .main2__title__left--text
-          %h3
-            %span.spancolor 3分で
-            ですぐに出品
-          .main2__title__left--text--sub
-            %P スマホで入力するだけで簡単に出品できる！
-      %li.main2__title__center
-        = image_tag('/assets/pict-reason-02.jpg',size: '280x280')
-        %span
-          .main2__title__center--num
-            2
-        .main2__title__center--text
-          %h3
-            %span.spancolor シンプル
-            で使いやすい
-          .main2__title__center--text--sub
-            %p めんどくさい入力は必要なく、検索に購入もスムーズ！
-      %li.main2__title__right
-        = image_tag('/assets/pict-reason-03.jpg',size: '280x280')
-        %span
-          .main2__title__right--num
-            3
-        .main2__title__right--text
-          %h3
-            手数料
-            %span.spancolor 業界最安
-          .main2__title__right--text--sub
-            %p 最大3%でお得に出品&購入！
-.main3
-  .main3__page
-    .main3__title
-      %h4 会員数日本一位
-    .main3__subtitle
-      %p FURIMAは、フリマアプリで最も人気。
-      %p 出品・購入回数も業界最多です！
-      %p ほしかったあの商品に出会えるかもしれません。
-    .main3__apple
-    .main3__google
-.main4
-  .main4__page
-    .main4__heading
-      %h2 FURIMAの特徴
-    .main4__title
-      .main4__title__left
-        = image_tag('/assets/icon-01.png',size: '154x237')
-        .main4__title__left--text
-          %h3 簡単に売り買いできる
-        .main4__title__left--sub
-          %P スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
-      .main4__title__center
-        = image_tag('/assets/icon-03.png',size: '154x237')
-        .main4__title__center--text
-          %h3 売上金は即日振込みに対応
-          .main4__title__center--text--sub
-            %p 午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします!
-      .main4__title__right
-        = image_tag('/assets/icon-04.png',size: '154x237')
-        .main4__title__right--text
-          %h3 様々な支払いに対応
-          .main4__title__right--text--sub
-            %p お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
-.main5
-  .main5__page
-    .main5__picupcategory
-      %p ピックアップカテゴリー
-    .main5__newlist
-      %span.spancolor 新規投稿商品
-    .main5__itemlist
-      .main5__itemlist--left
-        .main5__itemlist--left--pic
+.wrapper
+  .sellbtn
+    %span
+      .sellbtn__text
+        出品する
+      = image_tag "icon_camera.png",size: '70x70'
+  = render partial: 'items/main-header'
+  .main1
+    .main1__page
+      .main1__title
+        %h1 人生を変えるフリマアプリ
+      .main1__subtitle
+        %p FURIMAはだれでもかんたんに出品・購入できる
+        %p フリマアプリです
+      .main1__btn
+        .main1__btn--apple
+          = image_tag('/assets/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg',size: '180x53')
+        .main1__btn--google
+          = image_tag('/assets/google-play-badge.png',size: '200x73')
+  .main2
+    .main2__page
+      .main2__heading
+        %h2 FURIMAが選ばれる3つの理由
+      %ul.main2__title
+        %li.main2__title__left
+          = image_tag('/assets/pict-reason-01.jpg',size: '280x280')
+          %span 
+            .main2__title__left--num
+              1
+          .main2__title__left--text
+            %h3
+              %span.spancolor 3分で
+              ですぐに出品
+            .main2__title__left--text--sub
+              %P スマホで入力するだけで簡単に出品できる！
+        %li.main2__title__center
+          = image_tag('/assets/pict-reason-02.jpg',size: '280x280')
+          %span
+            .main2__title__center--num
+              2
+          .main2__title__center--text
+            %h3
+              %span.spancolor シンプル
+              で使いやすい
+            .main2__title__center--text--sub
+              %p めんどくさい入力は必要なく、検索に購入もスムーズ！
+        %li.main2__title__right
+          = image_tag('/assets/pict-reason-03.jpg',size: '280x280')
+          %span
+            .main2__title__right--num
+              3
+          .main2__title__right--text
+            %h3
+              手数料
+              %span.spancolor 業界最安
+            .main2__title__right--text--sub
+              %p 最大3%でお得に出品&購入！
+  .main3
+    .main3__page
+      .main3__title
+        %h4 会員数日本一位
+      .main3__subtitle
+        %p FURIMAは、フリマアプリで最も人気。
+        %p 出品・購入回数も業界最多です！
+        %p ほしかったあの商品に出会えるかもしれません。
+      .main3__apple
+      .main3__google
+  .main4
+    .main4__page
+      .main4__heading
+        %h2 FURIMAの特徴
+      .main4__title
+        .main4__title__left
           = image_tag('/assets/icon-01.png',size: '154x237')
-        .main5__itemlist--left--name
-          product1
-        .main5__itemlist--left--price
-          30000円
-      .main5__itemlist--center
-        .main5__itemlist--center--pic
-          = image_tag('/assets/icon-01.png',size: '154x237')
-        .main5__itemlist--center--name
-          product2
-        .main5__itemlist--center--price
-          40000円
-      .main5__itemlist--right
-        .main5__itemlist--right--pic
-          = image_tag('/assets/icon-01.png',size: '154x237')
-        .main5__itemlist--right--name
-          product3
-        .main5__itemlist--right--price
-          50000円
-.main6
-  .main6__page
-    .main6__title
-      %h4 だれでもかんたん、人生を変えるフリマアプリ
-    .main6__subtitle
-      %p 今すぐ無料ダウンロード！
-    .main6__btn
-      .main6__btn--apple
-        = image_tag('/assets/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg',size: '180x53')
-      .main6__btn--google
-        = image_tag('/assets/google-play-badge.png',size: '200x73')
+          .main4__title__left--text
+            %h3 簡単に売り買いできる
+          .main4__title__left--sub
+            %P スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
+        .main4__title__center
+          = image_tag('/assets/icon-03.png',size: '154x237')
+          .main4__title__center--text
+            %h3 売上金は即日振込みに対応
+            .main4__title__center--text--sub
+              %p 午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします!
+        .main4__title__right
+          = image_tag('/assets/icon-04.png',size: '154x237')
+          .main4__title__right--text
+            %h3 様々な支払いに対応
+            .main4__title__right--text--sub
+              %p お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
+  .main5
+    .main5__page
+      .main5__picupcategory
+        %p ピックアップカテゴリー
+      .main5__newlist
+        %span.spancolor 新規投稿商品
+      .main5__itemlist
+        .main5__itemlist--left
+          .main5__itemlist--left--pic
+            = image_tag('/assets/icon-01.png',size: '154x237')
+          .main5__itemlist--left--name
+            product1
+          .main5__itemlist--left--price
+            30000円
+        .main5__itemlist--center
+          .main5__itemlist--center--pic
+            = image_tag('/assets/icon-01.png',size: '154x237')
+          .main5__itemlist--center--name
+            product2
+          .main5__itemlist--center--price
+            40000円
+        .main5__itemlist--right
+          .main5__itemlist--right--pic
+            = image_tag('/assets/icon-01.png',size: '154x237')
+          .main5__itemlist--right--name
+            product3
+          .main5__itemlist--right--price
+            50000円
+  .main6
+    .main6__page
+      .main6__title
+        %h4 だれでもかんたん、人生を変えるフリマアプリ
+      .main6__subtitle
+        %p 今すぐ無料ダウンロード！
+      .main6__btn
+        .main6__btn--apple
+          = image_tag('/assets/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg',size: '180x53')
+        .main6__btn--google
+          = image_tag('/assets/google-play-badge.png',size: '200x73')
 
-.footer
+  .footer
 


### PR DESCRIPTION
# What
実装漏れしていたトップページの出品ボタンを追加（link_toはnewが完成していないので未実装）

# Why
フリマアプリの一番大事な要素の出品をいつでもどこでも出来るように。
商品がないと見るひとがいなくなり、見る人がいないと売る人も出品しても売れないためいなくなる。そのため出品は出来るだけやりやすく、なるべく多くの物が出品されるように。