### PR TITLE
購入確認画面の微修正

### DIFF
--- a/app/assets/stylesheets/buyers.scss
+++ b/app/assets/stylesheets/buyers.scss
@@ -126,6 +126,7 @@
 
             a {
               text-decoration: none;
+              color: #0099E8;
               }
 
 
@@ -154,12 +155,29 @@
 
         &-address {
           width: 343px;
-          padding: 40px 0 40px 0;
+          padding: 20px 0 80px 0;
           border-bottom: 1px solid #f5f5f5;
 
           &-info {
-            font-size: 16px;
+            display: flex;
+            justify-content: space-between;
             font-weight: bold;
+
+            &-left {
+              font-size: 14px;
+              font-weight: bold;
+            }
+
+            &-right {
+              font-size: 14px;
+              font-weight: bold;
+              text-align: right;
+            }
+
+            a {
+              text-decoration: none;
+              color: #0099E8;
+              }
           }
 
           &-box {
@@ -187,7 +205,7 @@
         
         &-confirm {
           width: 343px;
-          padding-top: 25px;
+          padding-top: 15px;
 
           &-btm {
             width: 100%;

--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -1,25 +1,31 @@
 class BuyersController < ApplicationController
 
   require 'payjp' #Payjpの読み込み
-  before_action :authenticate_user!, :set_card, :set_item
+  before_action :authenticate_user!, :set_card, :set_item, :set_address
 
   def index
     if @card.blank?                                                       #登録された情報がない場合にカード登録画面に移動
-      redirect_to new_card_path
+      
     else
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]                            #保管した顧客IDでpayjpから情報取得
       customer = Payjp::Customer.retrieve(@card.customer_id)              #保管したカードIDでpayjpから情報取得、
       @default_card_information = customer.cards.retrieve(@card.card_id)  #カード情報表示のためインスタンス変数に代入
     end
+
   end
 
   def pay
+    if @card.blank? 
+      redirect_to new_card_path and return
+    else
+
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     Payjp::Charge.create(
       amount: @item.selling_price,         #支払金額を引っ張ってくる
       customer: @card.customer_id,         #顧客ID
       currency: 'jpy',                     #日本円
   )
+    end
     redirect_to done_buyers_path #購入確定画面に移動
   end
 
@@ -29,11 +35,15 @@ class BuyersController < ApplicationController
   private
 
   def set_card
-    @card = Card.find_by(user_id: current_user.id)  #カードテーブルからpayjpの顧客IDを検索
+    @card = Card.find_by(user_id: current_user.id)   #カードテーブルからpayjpの顧客IDを検索
+  end
+
+  def set_address
+    @address = Address.find_by(id: current_user.id)  #アドレステーブルからIDを検索
   end
 
   def set_item
-    @item = Item.find(params[:id])                  #アイテムテーブルから情報を取得する
+    @item = Item.find(params[:id])                   #アイテムテーブルから情報を取得する
   end
 
 end

--- a/app/views/buyers/index.html.haml
+++ b/app/views/buyers/index.html.haml
@@ -8,7 +8,8 @@
       購入内容の確認
 
     .buy-main__middle
-      = image_tag @item.images[0].image.url
+      .buy-main__middle-image
+        = image_tag @item.images[0].image.url
       .buy-main__middle-item
         .buy-main__middle-item-name
           = @item.name
@@ -44,16 +45,27 @@
               = "有効期限：" + exp_month + " / " + exp_year
             %br
         .buy-main__bottom-form-address
+
           .buy-main__bottom-form-address-info
-            配送先
+            .buy-main__bottom-form-address-info-left
+              配送先
+            .buy-main__bottom-form-address-info-right
+              -# = link_to "変更する",new_address_path, class:"buy-main__bottom-form-address-info-right--update" 
+              -# マイページで変更できるようになれば作成する。
+
           .buy-main__bottom-form-address-box
-            〒111-1111
-            %br
-            東京都渋谷区1-11−111
-            %br
-            山田太郎
-            -# = fa_icon "plus-circle", class: "buy-main__bottom-form-address-box--icon" 今後、アドレスのインスタンスを使用する際に使用する可能性がある。
-            -# = link_to "登録して下さい","#", class:"buy-main__bottom-form-address-box--entry"
+            - if @address.blank? 
+              = fa_icon "plus-circle", class: "buy-main__bottom-form-address-box--icon" 
+              = link_to "登録して下さい", new_address_path, class:"buy-main__bottom-form-address-box--entry"
+              %br
+            - else
+              = "〒#{@address.postal_code.to_s}"
+              %br
+              = @address.prefecture
+              %br
+              = @address.city
+              %br
+              = @address.block
 
         .buy-main__bottom-form-confirm
           = form_tag(action: :pay, method: :post) do

--- a/app/views/items/_main-footer.html.haml
+++ b/app/views/items/_main-footer.html.haml
@@ -105,5 +105,5 @@
                 United States
   .main-footer-logo
     = link_to "#", class: "main-fotter-logo__icon" do
-      =image_tag("logo-white.png")
+      =image_tag("/logo-white.png")
     %p.main-fotter-logo__copyright © 2020 FURIMA


### PR DESCRIPTION
#WHAT
・購入確認画面の画像にCSSが当たってない箇所があるためを修正しました
・アドレスのデータベースを購入確認画面でも表示できるようにしました
・クレジットカードが登録されていない場合、購入ボタンを押すと登録画面に遷移させました

#WHY
・画像が小さくて確認できないため
・後藤さんがアドレスを登録できるようしていただいたので、
　購入確認ページでも表示できるようにしました
・クレジットカードがないと購入できないようにするためです