### PR TITLE
サインアップ画面の修正（確認用パスワードの導入）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,8 @@ class ApplicationController < ActionController::Base
 
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    added_attrs = [:nickname, :email, :password, :password_confirmation ]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
   end
 
   private

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,26 +10,38 @@
           .singup-main__container__content__form__group
             %ul.singup-main__container__content__form__group__box
               %li.singup-main__container__content__form__group__box__type
-                ニックネーム
+                = f.label :nickname, 'ニックネーム'
               %li.singup-main__container__content__form__group__box__terms
                 必須
-            = f.text_field :nickname, autofocus: true, class:"singup-main__container__content__form__group__text",placeholder:"例）メルカリ太郎"
+              %br/
+              = f.text_field :nickname, autofocus: true, autocomplete: "nickname", placeholder: "例)メルカリ太郎",class:"singup-main__container__content__form__group__text"
 
           .singup-main__container__content__form__group
             %ul.singup-main__container__content__form__group__box
               %li.singup-main__container__content__form__group__box__type
-                メールアドレス
+                = f.label :email, 'メールアドレス'
               %li.singup-main__container__content__form__group__box__terms
                 必須
-            = f.email_field :email, autofocus: true, class:"singup-main__container__content__form__group__text",placeholder:"PC・携帯どちらでも可"
+              %br/
+              = f.email_field :email, autocomplete: "email", class:"singup-main__container__content__form__group__text",placeholder:"PC・携帯どちらでも可"
 
           .singup-main__container__content__form__group
             %ul.singup-main__container__content__form__group__box
               %li.singup-main__container__content__form__group__box__type
-                パスワード
+                = f.label :password, 'パスワード'
               %li.singup-main__container__content__form__group__box__terms
                 必須
-            = f.password_field :password, autocomplete: "off", class:"singup-main__container__content__form__group__text",placeholder:"7文字以上の半角英数字"
+              %br/
+              = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上" , class:"singup-main__container__content__form__group__text"
+          
+          .singup-main__container__content__form__group
+            %ul.singup-main__container__content__form__group__box
+              %li.singup-main__container__content__form__group__box__type
+                = f.label :password_confirmation, 'パスワード（確認）'
+              %li.singup-main__container__content__form__group__box__terms
+                必須
+              %br/
+              = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "7文字以上",class:"singup-main__container__content__form__group__text"
             
           .singup-main__container__content__form__group
             .singup-main__container__content__form__group__checkbox


### PR DESCRIPTION
#WHAT
新規登録画面の修正。必須である確認用パスワードの追加

#WHY
本アプリに必要な為
