### PR TITLE
3nd-buyers-sever-side

### DIFF
--- a/app/assets/stylesheets/buyers.scss
+++ b/app/assets/stylesheets/buyers.scss
@@ -140,7 +140,7 @@
 
             &--icon {
               color: #0099e8;
-              margin-top: 5px;
+              margin-top: 2px;
             }
 
             &--entry {
@@ -190,7 +190,7 @@
 
             &--icon {
               color: #0099e8;
-              margin-top: 5px;
+              margin-top: 2px;
             }
 
             &--entry {

--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -16,7 +16,7 @@ class BuyersController < ApplicationController
 
   def pay
     if @card.blank? 
-      redirect_to new_card_path and return
+      redirect_to new_card_path, alert:'お支払い方法を登録してください' and return
     else
 
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']

--- a/app/views/buyers/index.html.haml
+++ b/app/views/buyers/index.html.haml
@@ -8,8 +8,7 @@
       購入内容の確認
 
     .buy-main__middle
-      .buy-main__middle-image
-        = image_tag @item.images[0].image.url
+      = image_tag @item.images[0].image.url, class:"buy-main__middle-image"
       .buy-main__middle-item
         .buy-main__middle-item-name
           = @item.name


### PR DESCRIPTION
#WHAT
クレジットカード登録せず、購入ボタンを押した際に
マイページの登録画面に遷移し、アラートを表示させる
#WHY
購入にはクレジットカード登録が必要なため