### PR TITLE
パンくずの実装

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -2,6 +2,20 @@
 .item-detail
   .item-detail__top
     .item-detail__top__box
+      = link_to  root_path, class: 'submit-btn-link' do
+        FURIMA
+      %span　>　
+      = link_to  root_path, class: 'submit-btn-link' do
+        = @item.category.parent.parent.name
+      %span　>　
+      = link_to  root_path, class: 'submit-btn-link' do 
+        = @item.category.parent.name
+      %span　>　
+      = link_to  root_path, class: 'submit-btn-link' do
+        = @item.category.name
+      %span　>　
+      = link_to  root_path, class: 'submit-btn-link' do
+        = @item.name
       .item-detail__top__box__item-name 
         = @item.name
       .item-detail__top__box__item-image


### PR DESCRIPTION
# What
商品詳細ページにパンくずの実装
（今回はカテゴリ毎の一覧を作っていないためリンク先は全てルートパスとしています）

# Why
ECサイトを利用している際に便利だと思っていたため
カテゴリの親、子、孫の名前の取得ができているのであれば実装自体はすぐに出来そうだと判断したため
<img width="1171" alt="9bf0cb2d3757f2a862cbeb17cb387715" src="https://user-images.githubusercontent.com/59317031/81828634-f5c08000-9574-11ea-8190-dea8742cfa90.png">
