### PR TITLE
ルートパスの修正

### DIFF
--- a/app/views/modules/_mypage-left.html.haml
+++ b/app/views/modules/_mypage-left.html.haml
@@ -38,7 +38,7 @@
           支払い方法
           %i.fa.fa-chevron-right
       %li
-        = link_to edit_user_registration_path, method: :get, class: "mypage-nav__list__item" do
+        = link_to edit_user_path, method: :get, class: "mypage-nav__list__item" do
           メール/パスワード
           %i.fa.fa-chevron-right
       %li


### PR DESCRIPTION
#What
マイページ内の「メール/パスワード」ページのルートパスを修正。

#why
「メール/パスワード」が意図したページに飛ばなかった為修正を行った。