### PR TITLE
単体テストエラーの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem 'merge_db_schema'
 gem 'active_hash'
 gem 'payjp'
 gem 'faker', "~> 2.8"
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.1)
       actionpack (= 5.2.4.1)
       activesupport (= 5.2.4.1)
@@ -375,6 +378,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -12,105 +12,105 @@ describe Address do
     it "familynameがない場合は登録できないこと" do
       address = build(:address, familyname: nil)
       address.valid?
-      expect(address.errors[:familyname]).to include("can't be blank")
+      expect(address.errors[:familyname]).to include("を入力してください")
     end
 
     # 3
     it "firstnameがない場合は登録できないこと" do
       address = build(:address, firstname: nil)
       address.valid?
-      expect(address.errors[:firstname]).to include("can't be blank")
+      expect(address.errors[:firstname]).to include("を入力してください")
     end
 
     # 4
     it "familyname_kanaがない場合は登録できないこと" do
       address = build(:address, familyname_kana: nil)
       address.valid?
-      expect(address.errors[:familyname_kana]).to include("can't be blank")
+      expect(address.errors[:familyname_kana]).to include("を入力してください")
     end
     
     # 5
     it "firstname_kanaがない場合は登録できないこと" do
       address = build(:address, firstname_kana: nil)
       address.valid?
-      expect(address.errors[:firstname_kana]).to include("can't be blank")
+      expect(address.errors[:firstname_kana]).to include("を入力してください")
     end
 
     # 6
     it "birth_yearがない場合は登録できないこと" do
       address = build(:address, birth_year: nil)
       address.valid?
-      expect(address.errors[:birth_year]).to include("can't be blank")
+      expect(address.errors[:birth_year]).to include("を入力してください")
     end
 
     # 7
     it "birth_monthがない場合は登録できないこと" do
       address = build(:address, birth_month: nil)
       address.valid?
-      expect(address.errors[:birth_month]).to include("can't be blank")
+      expect(address.errors[:birth_month]).to include("を入力してください")
     end
 
     # 8
     it "birth_dayがない場合は登録できないこと" do
       address = build(:address, birth_day: nil)
       address.valid?
-      expect(address.errors[:birth_day]).to include("can't be blank")
+      expect(address.errors[:birth_day]).to include("を入力してください")
     end
 
     # 9
     it "familyname_deliverがない場合は登録できないこと" do
       address = build(:address, familyname_deliver: nil)
       address.valid?
-      expect(address.errors[:familyname_deliver]).to include("can't be blank")
+      expect(address.errors[:familyname_deliver]).to include("を入力してください")
     end
 
     # 10
     it "firstname_deliverがない場合は登録できないこと" do
       address = build(:address, firstname_deliver: nil)
       address.valid?
-      expect(address.errors[:firstname_deliver]).to include("can't be blank")
+      expect(address.errors[:firstname_deliver]).to include("を入力してください")
     end
 
     # 11
     it "familyname_deliver_kanaがない場合は登録できないこと" do
       address = build(:address, familyname_deliver_kana: nil)
       address.valid?
-      expect(address.errors[:familyname_deliver_kana]).to include("can't be blank")
+      expect(address.errors[:familyname_deliver_kana]).to include("を入力してください")
     end
     
     # 12
     it "firstname_deliver_kanaがない場合は登録できないこと" do
       address = build(:address, firstname_deliver_kana: nil)
       address.valid?
-      expect(address.errors[:firstname_deliver_kana]).to include("can't be blank")
+      expect(address.errors[:firstname_deliver_kana]).to include("を入力してください")
     end
     
     # 13
     it "postal_codeがない場合は登録できないこと" do
       address = build(:address, postal_code: nil)
       address.valid?
-      expect(address.errors[:postal_code]).to include("can't be blank")
+      expect(address.errors[:postal_code]).to include("を入力してください")
     end
 
     # 14
     it "prefectureがない場合は登録できないこと" do
       address = build(:address, prefecture: nil)
       address.valid?
-      expect(address.errors[:prefecture]).to include("can't be blank")
+      expect(address.errors[:prefecture]).to include("を入力してください")
     end
 
     # 15
     it "cityがない場合は登録できないこと" do
       address = build(:address, city: nil)
       address.valid?
-      expect(address.errors[:city]).to include("can't be blank")
+      expect(address.errors[:city]).to include("を入力してください")
     end
 
     # 16
     it "blockがない場合は登録できないこと" do
       address = build(:address, block: nil)
       address.valid?
-      expect(address.errors[:block]).to include("can't be blank")
+      expect(address.errors[:block]).to include("を入力してください")
     end
 
     # 17

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -13,21 +13,21 @@ describe Card do
     it "user_idがない場合は登録できないこと" do
       card = build(:card, user: nil)
       card.valid?
-      expect(card.errors[:user]).to include("must exist")
+      expect(card.errors[:user]).to include("を入力してください")
     end
 
     # 3
     it "customer_idがない場合は登録できないこと" do
       card = build(:card, customer_id: nil)
       card.valid?
-      expect(card.errors[:customer_id]).to include("can't be blank")
+      expect(card.errors[:customer_id]).to include("を入力してください")
     end
     
     # 4
     it "card_idがない場合は登録できないこと" do
       card = build(:card, card_id: nil)
       card.valid?
-      expect(card.errors[:card_id]).to include("can't be blank")
+      expect(card.errors[:card_id]).to include("を入力してください")
     end
     
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,59 +12,59 @@ describe Item do
     it "nameがない場合は登録できないこと" do
       item = build(:item, name: nil)
       item.valid?
-      expect(item.errors[:name]).to include("can't be blank")
+      expect(item.errors[:name]).to include("を入力してください")
     end
 
     # 3
     it "textがない場合は登録できないこと" do
       item = build(:item, text: nil)
       item.valid?
-      expect(item.errors[:text]).to include("can't be blank")
+      expect(item.errors[:text]).to include("を入力してください")
     end
 
     # 4
     it "category_idがない場合は登録できないこと" do
       item = build(:item, category_id: nil)
       item.valid?
-      expect(item.errors[:category_id]).to include("can't be blank")
+      expect(item.errors[:category_id]).to include("を入力してください")
     end
 
     # 5
     it "status_idがない場合は登録できないこと" do
       item = build(:item, status_id: nil)
       item.valid?
-      expect(item.errors[:status_id]).to include("can't be blank")
+      expect(item.errors[:status_id]).to include("を入力してください")
     end
     # 6
     it "area_idがない場合は登録できないこと" do
       item = build(:item, area_id: nil)
       item.valid?
-      expect(item.errors[:area_id]).to include("can't be blank")
+      expect(item.errors[:area_id]).to include("を入力してください")
     end
     # 7
     it "burden_idがない場合は登録できないこと" do
       item = build(:item, burden_id: nil)
       item.valid?
-      expect(item.errors[:burden_id]).to include("can't be blank")
+      expect(item.errors[:burden_id]).to include("を入力してください")
     end
     # 8
     it "days_to_ship_idがない場合は登録できないこと" do
       item = build(:item, days_to_ship_id: nil)
       item.valid?
-      expect(item.errors[:days_to_ship_id]).to include("can't be blank")
+      expect(item.errors[:days_to_ship_id]).to include("を入力してください")
     end
     # 9
     it "selling_priceがない場合は登録できないこと" do
       item = build(:item, selling_price: nil)
       item.valid?
-      expect(item.errors[:selling_price]).to include("can't be blank")
+      expect(item.errors[:selling_price]).to include("を入力してください")
     end
 
     # 10
     it " nameが41文字以上であれば登録できないこと" do
       item = build(:item, name: "aaaaaaaaaabbbbbcbbbbbccccccccccdddddddddde")
       item.valid?
-      expect(item.errors[:name]).to include("is too long (maximum is 40 characters)")
+      expect(item.errors[:name]).to include("は40文字以内で入力してください")
     end
 
     # 11
@@ -86,13 +86,13 @@ describe Item do
     it "selling_priceが300以下では登録できない " do
       item = build(:item, selling_price: "200")
       item.valid?
-      expect(item.errors[:selling_price]).to include("must be greater than 299")
+      expect(item.errors[:selling_price]).to include("は299より大きい値にしてください")
     end
     # 15
     it "saler_idが空では登録できない " do
       item = build(:item, saler_id: "")
       item.valid?
-      expect(item.errors[:saler_id]).to include("can't be blank")
+      expect(item.errors[:saler_id]).to include("を入力してください")
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,28 +12,28 @@ describe User do
     it "nicknameがない場合は登録できないこと" do
       user = build(:user, nickname: nil)
       user.valid?
-      expect(user.errors[:nickname]).to include("can't be blank")
+      expect(user.errors[:nickname]).to include("を入力してください")
     end
 
     # 3
     it "emailがない場合は登録できないこと" do
       user = build(:user, email: nil)
       user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      expect(user.errors[:email]).to include("を入力してください")
     end
 
     # 4
     it "encrypted_passwordがない場合は登録できないこと" do
       user = build(:user, encrypted_password: nil)
       user.valid?
-      expect(user.errors[:encrypted_password]).to include("can't be blank")
+      expect(user.errors[:encrypted_password]).to include("を入力してください")
     end
 
     # 5
     it "encrypted_passwordが6文字以下では登録できないこと" do
       user = build(:user, encrypted_password: "123456")
       user.valid?
-      expect(user.errors[:encrypted_password]).to include("is too short (minimum is 7 characters)")
+      expect(user.errors[:encrypted_password]).to include("は7文字以上で入力してください")
     end
 
     it "encrypted_passwordが7文字以上で登録できること" do
@@ -49,20 +49,20 @@ describe User do
       #先に登録したユーザーと同じemailの値をもつユーザーのインスタンスを作成
       another_user = build(:user)
       another_user.valid?
-      expect(another_user.errors[:email]).to include("has already been taken")
+      expect(another_user.errors[:email]).to include("はすでに存在します")
     end
 
     # 7
     it "emailに＠が含まれていないと登録できない" do
       user = build(:user, email: "aaaagmail.com")
       user.valid?
-      expect(user.errors[:email]).to include("is invalid")
+      expect(user.errors[:email]).to include("は不正な値です")
     end
 
     it "emailにドメインが含まれていないと登録できない" do
       user = build(:user, email: "aaaa@")
       user.valid?
-      expect(user.errors[:email]).to include("is invalid")
+      expect(user.errors[:email]).to include("は不正な値です")
     end
 
     # 8
@@ -75,7 +75,7 @@ describe User do
     it "passwordとpassword_confirmationが一致していないと登録できない " do
       user = build(:user, password: "a123456", password_confirmation: "b987654")
       user.valid?
-      expect(user.errors[:password_confirmation]).to include("doesn't match Password")
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
   end
 end


### PR DESCRIPTION
# WHAT
・gemfileにgem 'rails-i18n'を追加
・単体テストのエラー文を日本語に修正
単体テストの結果は全てOK
https://gyazo.com/3a634c5ca3c8b539d1ca35c4824c1b43

# WHY
単体テストで
expected ["translation missing: ja.activerecord.errors.models.user.attributes.email.blank", "translation missing: ja.activerecord.errors.models.user.attributes.email.invalid"] to include "can't be blank"
というエラー文が出てしまった。
私が単体テストの一部で、
エラー文を日本語にしてしまったことがエラーの原因かもしれない。
修正後に考えると、日本語記述を英語にした方が早かったかもしれない。