### PR TITLE
配送先をベタ打ちに変更

### DIFF
--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -1,7 +1,7 @@
 class BuyersController < ApplicationController
 
   require 'payjp' #Payjpの読み込み
-  before_action :authenticate_user!, :set_card, :set_item, :set_address
+  before_action :authenticate_user!, :set_card, :set_item, 
 
   def index
     if @card.blank?
@@ -37,10 +37,6 @@ class BuyersController < ApplicationController
 
   def set_card
     @card = Card.find_by(user_id: current_user.id)   #カードテーブルからpayjpの顧客IDを検索
-  end
-
-  def set_address
-    @address = Address.find_by(id: current_user.id)  #アドレステーブルからIDを検索
   end
 
   def set_item

--- a/app/views/buyers/index.html.haml
+++ b/app/views/buyers/index.html.haml
@@ -49,22 +49,14 @@
             .buy-main__bottom-form-address-info-left
               配送先
             .buy-main__bottom-form-address-info-right
-              -# = link_to "変更する",new_address_path, class:"buy-main__bottom-form-address-info-right--update" 
-              -# マイページで変更できるようになれば作成する。
 
           .buy-main__bottom-form-address-box
-            - if @address.blank? 
-              = fa_icon "plus-circle", class: "buy-main__bottom-form-address-box--icon" 
-              = link_to "登録して下さい", new_address_path, class:"buy-main__bottom-form-address-box--entry"
-              %br
-            - else
-              = "〒#{@address.postal_code.to_s}"
-              %br
-              = @address.prefecture
-              %br
-              = @address.city
-              %br
-              = @address.block
+            %br
+            東京都
+            %br
+            中央区
+            %br
+            日本橋１−１−１
 
         .buy-main__bottom-form-confirm
           = form_tag(action: :pay, method: :post) do


### PR DESCRIPTION
#WHAT
配送先住所をベタ打ちに変更
＃WHY
必須実装ではないため
アドレスのデータベースに都道府県が文字で保存されておらず、使用できないため