### PR TITLE
カテゴリの一覧表示

### DIFF
--- a/app/assets/stylesheets/_main-header.scss
+++ b/app/assets/stylesheets/_main-header.scss
@@ -37,12 +37,17 @@
       }
       #sbtn {
         position: absolute;
-        top: 5px;
-        right: 10px;
+        top: 0px;
+        right: 0px;
         width: 36px;
-        line-height: 36px;
+        height: 36px;
+        border: 0;
         cursor: pointer;
-        text-align: center;
+        background-color: #3CCACE;
+        color: white;
+        padding: 8px;
+        box-sizing: border-box;
+        border: 1px solid #ffffff;
       }
 
       }
@@ -121,4 +126,14 @@
       }
     }
   }
+}
+
+.btn-primary {
+  position: absolute;
+  top: 0px;
+  right: 19px;
+  width: 0px;
+  height: 0px;
+  border: 0;
+  
 }

--- a/app/assets/stylesheets/_main-header.scss
+++ b/app/assets/stylesheets/_main-header.scss
@@ -26,8 +26,8 @@
       a {
         color: black;
       }
-      input {
-        width: 100%;
+      #search {
+        width: 90%;
         height: 36px;
         padding: 9px 32px 9px 8px;
         background: #fafafa;
@@ -35,10 +35,10 @@
         box-sizing: border-box;
         border: 1px solid #ccc;
       }
-      i {
+      #sbtn {
         position: absolute;
-        top: 0;
-        right: 0;
+        top: 5px;
+        right: 10px;
         width: 36px;
         line-height: 36px;
         cursor: pointer;

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -1,0 +1,48 @@
+.search {
+  padding: 20px;
+  background-color: #EEEEEE;
+  height: 100vh;
+  margin: auto;
+  text-align: center;
+  
+  &-list {
+    margin-bottom: 10px;
+
+    &-box {
+      margin: auto;
+      padding: 10px;
+      width: 700px;
+      display: flex;
+      justify-content: space-between;
+      background-color: white;
+
+      &-left {
+        
+        &-pic {
+
+        }
+        
+        &-price {
+
+        }
+      }
+
+      &-right {
+        width: 500px;
+        text-align: left;
+
+        &-name {
+          width: 500px;
+          height: 50px;
+          text-overflow: ellipsis;
+
+        }
+
+        &-text {
+          width: 500px;
+
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 @import "./header";
 @import "./show";
 @import "./edit";
+@import "./search";
 @import "./mypage-left";
 @import "./mypage";
 @import "./addresses";

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -62,6 +62,11 @@ class ItemsController < ApplicationController
     item.destroy
   end
 
+  def search
+    @items = Item.search(params[:search])
+  end
+
+
   
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -66,9 +66,9 @@ class ItemsController < ApplicationController
     @items = Item.search(params[:search])
   end
 
-  # def lady
-  #   @item = Item.where(category_id: )
-  # end
+  def lady
+    @items = Item.where(category: 1..199)
+  end
 
 
   
@@ -99,6 +99,5 @@ class ItemsController < ApplicationController
   def user_address
     redirect_to root_path, alert:"出品するためには本人情報の登録が必要です" if @current_user.address.blank?
   end
-
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -66,6 +66,10 @@ class ItemsController < ApplicationController
     @items = Item.search(params[:search])
   end
 
+  # def lady
+  #   @item = Item.where(category_id: )
+  # end
+
 
   
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,4 +17,9 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
 
+  def self.search(search)
+    return Item.all unless search
+    Item.where('text LIKE(?)', "%#{search}%")
+  end
+
 end

--- a/app/views/items/_main-header.html.haml
+++ b/app/views/items/_main-header.html.haml
@@ -4,10 +4,12 @@
       %li.main-header__container__logo-and-search__logo
         = link_to image_tag('/logo.png', height:'40', width: '134', alt: "ロゴ１"), root_path
       %li.main-header__container__logo-and-search__search
-        %form.main-header__container__logo-and-search__search__box
-          %input{value:"", placeholder:"何かお探しですか？" }
-            = link_to "#" do
-              %i.fa.fa-search
+        .main-header__container__logo-and-search__search__box
+        = form_with url: search_items_path, method: :get, local: true do |f|
+          .form-group
+            = f.text_field :search, class: 'form-control'
+          %i.fa.fa-search
+            = f.submit '検索する', class: 'btn btn-primary',id: 'sbtn', name: nil
     %ul.lists.clearfix
       %li.lists__left.left-float
         .categories

--- a/app/views/items/_main-header.html.haml
+++ b/app/views/items/_main-header.html.haml
@@ -8,8 +8,8 @@
         = form_with url: search_items_path, method: :get, local: true do |f|
           .form-group
             = f.text_field :search, class: 'form-control'
-          %i.fa.fa-search
-            = f.submit '検索する', class: 'btn btn-primary',id: 'sbtn', name: nil
+          = button_tag type: 'submit', class: 'btn-primary' do
+            = image_tag '/icon-search 1.png', alt: '', height: '36', width: '36', class: 'searchtest', id:'sbtn'
     %ul.lists.clearfix
       %li.lists__left.left-float
         .categories

--- a/app/views/items/lady.html.haml
+++ b/app/views/items/lady.html.haml
@@ -1,0 +1,25 @@
+.wrapper
+  = render partial: 'items/item-btn'
+  = render partial: 'items/main-header'
+
+  .search
+    レディース一覧
+    - @items.each do |item|
+      .search-list
+        %ul.search-list-box
+          %li.search-list-box-left
+            = link_to item_path(item.id), class:"search-show" do
+              .search-list-box-left-pic
+                = image_tag item.images[0].image.url, width: '100', height:'100'
+              .search-list-box-left-price
+                ¥
+                = item.selling_price
+                （税込）
+          %li.search-list-box-right
+            = link_to item_path(item.id), class:"search-show" do
+              .search-list-box-right-name
+                商品名：
+                = item.name
+              .search-list-box-right-text
+                商品説明：
+                = item.text

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -2,18 +2,23 @@
   = render partial: 'items/item-btn'
   = render partial: 'items/main-header'
 
-  .item
+  .search
     - @items.each do |item|
-      .item-list
-        .item-list-box
-        = link_to item_path(item.id), class:"search-show" do
-          .item-list-box-pic
-            = image_tag item.images[0].image.url, width: '100', height:'100'
-          .item-list-box-name
-            = item.name
-          .item-list-box-text
-            = item.text
-          .item-list-box-price
-            ¥
-            = item.selling_price
-            （税込）
+      .search-list
+        %ul.search-list-box
+          %li.search-list-box-left
+            = link_to item_path(item.id), class:"search-show" do
+              .search-list-box-left-pic
+                = image_tag item.images[0].image.url, width: '100', height:'100'
+              .search-list-box-left-price
+                ¥
+                = item.selling_price
+                （税込）
+          %li.search-list-box-right
+            = link_to item_path(item.id), class:"search-show" do
+              .search-list-box-right-name
+                商品名：
+                = item.name
+              .search-list-box-right-text
+                商品説明：
+                = item.text

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,19 @@
+.wrapper
+  = render partial: 'items/item-btn'
+  = render partial: 'items/main-header'
+
+  .item
+    - @items.each do |item|
+      .item-list
+        .item-list-box
+        = link_to item_path(item.id), class:"search-show" do
+          .item-list-box-pic
+            = image_tag item.images[0].image.url, width: '100', height:'100'
+          .item-list-box-name
+            = item.name
+          .item-list-box-text
+            = item.text
+          .item-list-box-price
+            ¥
+            = item.selling_price
+            （税込）

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,7 +6,7 @@
       = link_to  root_path, class: 'submit-btn-link' do
         FURIMA
       %span　>　
-      = link_to  root_path, class: 'submit-btn-link' do
+      = link_to  lady_items_path, class: 'submit-btn-link' do
         = @item.category.parent.parent.name
       %span　>　
       = link_to  root_path, class: 'submit-btn-link' do 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
       get 'search'
-      get 'ladys'
+      get 'lady'
     end
     member do
       get 'get_category_children', defaults: { format: 'json' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
+      get 'search'
+      get 'ladys'
     end
     member do
       get 'get_category_children', defaults: { format: 'json' }


### PR DESCRIPTION
# What
・レディースのカテゴリ一覧の実装
・今回はあくまでもカテゴリ一覧の実装が目的のため一つのカテゴリしか作成せず（今回はレディースの一覧）
※今回はパンくずの親にリンクを貼っています。下のIssuesにも記載しておりますが、メンズだろうがレディース一覧に飛ぶようになっています。

# Why
・自分がECサイトを使う時はよくカテゴリ一覧から探すなど、便利だと思っていたため
・サーチ機能実装にあたり、同じようなビューで実装可能だと判断したため
・パンくずを実装したのであれば欲しい機能だったため
・今回の最終課題には全然必要ないが欲しいと思ったため

# Issues
・ancestryでの親のIDと子IDでの抽出の仕方
そのため今回はレディースに含まれるcategory_idを直接指定してる1~199
・リンク先の設定の仕方
レディース一覧というリンクの文言を実装していればリンクできるがパンくずで、もしレディースならリンク先をレディース一覧へという条件式が思いつかない。もしくは思いついても全て設定しなければならない。