### PR TITLE
パスワードのバリデーションを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,8 @@ class User < ApplicationRecord
 
          validates :nickname, presence: true
          validates :email, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
-         validates :encrypted_password, presence: true, length:  { minimum: 7 }
+         validates :password, presence: true
+         validates :password_confirmation, presence: true
 
   has_many :items
   has_many :buyers

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe User do
   describe '#create' do
     # 1
-    it "nickname,email,encrypted_passwordが存在すれば登録できること" do
+    it "nickname,email,passwordが存在すれば登録できること" do
       user = build(:user)
       expect(user).to be_valid
     end
@@ -23,21 +23,21 @@ describe User do
     end
 
     # 4
-    it "encrypted_passwordがない場合は登録できないこと" do
-      user = build(:user, encrypted_password: nil)
+    it "passwordがない場合は登録できないこと" do
+      user = build(:user, password: nil)
       user.valid?
-      expect(user.errors[:encrypted_password]).to include("を入力してください")
+      expect(user.errors[:password]).to include("を入力してください")
     end
 
     # 5
-    it "encrypted_passwordが6文字以下では登録できないこと" do
-      user = build(:user, encrypted_password: "123456")
+    it "passwordが6文字以下では登録できないこと" do
+      user = build(:user, password: "123456",password_confirmation:"123456")
       user.valid?
-      expect(user.errors[:encrypted_password]).to include("は7文字以上で入力してください")
+      expect(user.errors[:password]).to include("は7文字以上で入力してください")
     end
 
-    it "encrypted_passwordが7文字以上で登録できること" do
-      user = build(:user, encrypted_password: "1234567")
+    it "passwordが7文字以上で登録できること" do
+      user = build(:user, password: "1234567",password_confirmation:"1234567")
       user.valid?
       expect(user).to be_valid
     end


### PR DESCRIPTION
# WHAT
・passwordのバリデーションの修正
deviseだったのでconfig/initializers/devise.rb の設定を直接修正した。
models/user.rbの制限は削除した
https://gyazo.com/839d293e9631c6bd838bd6a291846cc7

・passwordに関連した単体テストの修正
factorybotの上書き対象をencrypted_passwordにしていたのが
そもそもエラーの発見ができなかった原因だと思われるため。
（テスト結果はOK）
https://gyazo.com/e4232e93e52f0eab036e8ff8184f3835

#WHY
６文字のpasswordでユーザー登録できてしまったため