### PR TITLE
編集時のカテゴリのセレクトボックスに値残し、完成！！！

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,6 +45,12 @@ class ItemsController < ApplicationController
 
   def edit
     @category_parent_array = Category.where(ancestry: nil)
+    @grandchild_category = @item.category
+    @child_category = @item.category.parent
+    @parent_category = @item.category.root
+
+    @child = @parent_category.children
+    @grandchild = @child_category.children
   end
 
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -36,7 +36,10 @@
           %p.message 商品の詳細
           %p.message カテゴリー（必須)
           .sell-category-box
-            = f.collection_select :category_id, @category_parent_array, :id, :name, {prompt: "---"}, {class: 'sell__item-category', id: 'parent_category'}
+            = f.collection_select :category_id, @category_parent_array, :id, :name, {prompt: "", selected: @parent_category.id}, {class: 'sell__item-category', id: 'parent_category'}
+            = f.collection_select :category_id, @child, :id, :name, {prompt: "", selected: @child_category.id}, {class: 'sell__item-category', id: 'child_category'}
+            = f.collection_select :category_id, @grandchild, :id, :name, {}, {class: 'sell__item-category', id: 'grandchild_category'}
+
           %p.message ブランド (任意)
           = f.text_field :brand, class: "brand-box", placeholder: "例) シャネル"
           %p.message 商品の状態（必須）


### PR DESCRIPTION
# What
・編集時にカテゴリがデフォルトのレディースとなり、セレクトボックスも一つになってしまっていた部分をデータベースに保存されている物を表示させるように。
例：メンズ/トップス/Tシャツならメンズ、トップス、Tシャツとセレクトボックス３つ表示されるように修正

# Why
・ずっと編集時にレディースに戻ってしまう部分が気になっていたため。
（レディースに戻ってしまうせいで、親カテゴリのみで保存されてしまうため）
・他の部分でセレクトボックスの値が残っているので、単純に　jsで追加されるIDのセレクトボックスを追加したら戻ると思ったため