### PR TITLE
編集時画像なしで編集が完了した問題を修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,8 +58,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to item_path(@item.id), notice: "編集しました"
     else
-      flash.now[:alert] = "編集できません。入力必須項目を確認してください"
-      render :edit
+      redirect_to edit_item_path, alert: "編集できません。入力必須項目を確認してください"
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,7 @@ class Item < ApplicationRecord
   validates :category_id, :status_id, :burden_id, :area_id, :days_to_ship_id, :saler_id,presence: true
   validates :text, presence: true, length: { maximum: 1000 }
   validates :selling_price, presence: true, numericality: { greater_than: 299, less_than:10000000 }
+  validates :images, presence: true
   has_one :buyer
   belongs_to :category
   belongs_to :user, optional: true


### PR DESCRIPTION
# What
編集時に画像を削除して編集が完了しないように修正

# Why
画像に対するバリデーションがなかったため、画像を削除して編集完了するとそれが保存されてその後エラーにより見れなくなってしまうため